### PR TITLE
Remove Salt API dependency from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,6 @@ The following packages must be installed:
 .. code-block:: yaml
 
     - Salt (develop branch)
-    - Salt API >= 0.8.4.1
 
 
 Master Configuration


### PR DESCRIPTION
Salt API has been merged into Salt's develop branch,  so dependency shouldn't need to be listed anymore.
